### PR TITLE
Remove unsafety

### DIFF
--- a/src/primitive.rs
+++ b/src/primitive.rs
@@ -1,5 +1,5 @@
 use std::ops::{Deref, DerefMut};
-use std::{mem, fmt, cmp};
+use std::{fmt, cmp};
 use std::str::FromStr;
 use rustc_serialize::hex::{ToHex, FromHex};
 use Error;
@@ -25,7 +25,7 @@ macro_rules! impl_primitive {
 
 		impl FromStr for $name {
 			type Err = Error;
-			
+
 			fn from_str(s: &str) -> Result<Self, Self::Err> {
 				match s.from_hex() {
 					Ok(ref hex) if hex.len() == $size => {
@@ -78,13 +78,13 @@ macro_rules! impl_primitive {
 
 		impl From<[u8; $size]> for $name {
 			fn from(s: [u8; $size]) -> Self {
-				unsafe { mem::transmute(s) }
+				$name(s)
 			}
 		}
 
 		impl Into<[u8; $size]> for $name {
 			fn into(self) -> [u8; $size] {
-				unsafe { mem::transmute(self) }
+				self.0
 			}
 		}
 
@@ -92,13 +92,13 @@ macro_rules! impl_primitive {
 			type Target = [u8; $size];
 
 			fn deref(&self) -> &Self::Target {
-				unsafe { mem::transmute(self) }
+				&self.0
 			}
 		}
 
 		impl DerefMut for $name {
 			fn deref_mut(&mut self) -> &mut Self::Target {
-				unsafe { mem::transmute(self) }
+				&mut self.0
 			}
 		}
 	}

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -27,7 +27,7 @@ impl Signature {
 	}
 }
 
-// manual implementation of debug since large arrays don't have trait impls.
+// manual implementation large arrays don't have trait impls by default.
 // remove when integer generics exist
 impl ::std::cmp::PartialEq for Signature {
 	fn eq(&self, other: &Self) -> bool {

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -106,7 +106,7 @@ pub fn sign(secret: &Secret, message: &Message) -> Result<Signature, Error> {
 	let s = try!(context.sign_recoverable(&try!(SecpMessage::from_slice(message.deref())), sec));
 	let (rec_id, data) = s.serialize_compact(context);
 	let mut data_arr = [0; 65];
-	(&mut data_arr[0..64]).copy_from_slice(&data[0..64]);
+	data_arr[0..64].copy_from_slice(&data[0..64]);
 	data_arr[64] = rec_id.to_i32() as u8;
 	Ok(Signature(data_arr))
 }
@@ -118,7 +118,7 @@ pub fn verify(public: &Public, signature: &Signature, message: &Message) -> Resu
 
 	let pdata: [u8; 65] = {
 		let mut temp = [4u8; 65];
-		(&mut temp[1..65]).copy_from_slice(public.deref());
+		temp[1..65].copy_from_slice(public.deref());
 		temp
 	};
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -7,7 +7,7 @@ use rustc_serialize::hex::{ToHex, FromHex};
 use {Secret, Public, SECP256K1, Error, Message};
 
 #[repr(C)]
-#[derive(Debug, PartialEq)]
+#[derive(Eq)]
 pub struct Signature([u8; 65]);
 
 impl Signature {
@@ -24,6 +24,25 @@ impl Signature {
 	/// Get the recovery byte.
 	pub fn v(&self) -> u8 {
 		self.0[64]
+	}
+}
+
+// manual implementation of debug since large arrays don't have trait impls.
+// remove when integer generics exist
+impl ::std::cmp::PartialEq for Signature {
+	fn eq(&self, other: &Self) -> bool {
+		&self.0[..] == &other.0[..]
+	}
+}
+
+// also manual for the same reason, but the pretty printing might be useful.
+impl fmt::Debug for Signature {
+	fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+		f.debug_struct("Signature")
+			.field("r", &self.0[0..32].to_hex())
+			.field("s", &self.0[32..64].to_hex())
+			.field("v", &self.0[64..65].to_hex())
+		.finish()
 	}
 }
 

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -106,6 +106,8 @@ pub fn sign(secret: &Secret, message: &Message) -> Result<Signature, Error> {
 	let s = try!(context.sign_recoverable(&try!(SecpMessage::from_slice(message.deref())), sec));
 	let (rec_id, data) = s.serialize_compact(context);
 	let mut data_arr = [0; 65];
+
+	// no need to check if s is low, it always is
 	data_arr[0..64].copy_from_slice(&data[0..64]);
 	data_arr[64] = rec_id.to_i32() as u8;
 	Ok(Signature(data_arr))


### PR DESCRIPTION
also restructures `Signature` into a single byte array with immutable accessors.
this also guarantees that `Signature` will not be altered into something invalid by a user.
